### PR TITLE
refactor: Convert PrestaShop module to WordPress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Block Content Protection for PrestaShop
+# Block Content Protection for WordPress
 
-A comprehensive content protection module for PrestaShop 1.7 & 8+, designed to prevent content theft and unauthorized use.
+A comprehensive content protection plugin for WordPress, designed to prevent content theft and unauthorized use.
 
 **Developed by:** Mohammad Babaei - [adschi.com](https://adschi.com)
 
@@ -8,7 +8,7 @@ A comprehensive content protection module for PrestaShop 1.7 & 8+, designed to p
 
 ## Features
 
-This module provides a robust set of features to protect your website's content:
+This plugin provides a robust set of features to protect your website's content:
 
 -   **Disable Right-Click**: Prevents users from opening the context menu.
 -   **Block Developer Tools**: Blocks access to browser developer tools (F12, Ctrl+Shift+I, etc.).
@@ -21,18 +21,19 @@ This module provides a robust set of features to protect your website's content:
 
 ## How to Use
 
-1.  Download the latest release (`.zip` file) from the repository.
-2.  Log in to your PrestaShop back office.
-3.  Navigate to **Modules > Module Manager**.
-4.  Click **Upload a module** and select the downloaded `.zip` file.
-5.  After installation, click **Configure** and enable the protection features you need.
+1.  Download the latest release (`.zip` file).
+2.  Log in to your WordPress admin dashboard.
+3.  Navigate to **Plugins > Add New**.
+4.  Click **Upload Plugin** and select the downloaded `.zip` file.
+5.  After installation, click **Activate**.
+6.  Configure the settings by navigating to **Settings > Content Protection**. Enable the protection features you need.
 
 ---
 ---
 
-# ماژول محافظت از محتوا برای پرستاشاپ
+# پلاگین محافظت از محتوا برای وردپرس
 
-یک ماژول جامع برای محافظت از محتوای فروشگاه‌های پرستاشاپ (نسخه ۱.۷ و ۸ به بالا)، طراحی‌شده برای جلوگیری از سرقت محتوا و استفاده غیرمجاز.
+یک پلاگین جامع برای محافظت از محتوای وب‌سایت‌های وردپرسی، طراحی‌شده برای جلوگیری از سرقت محتوا و استفاده غیرمجاز.
 
 **توسعه‌دهنده:** محمد بابایی - [adschi.com](https://adschi.com)
 
@@ -40,7 +41,7 @@ This module provides a robust set of features to protect your website's content:
 
 ## ویژگی‌ها
 
-این ماژول مجموعه‌ای از قابلیت‌های قدرتمند را برای حفاظت از محتوای وب‌سایت شما فراهم می‌کند:
+این پلاگین مجموعه‌ای از قابلیت‌های قدرتمند را برای حفاظت از محتوای وب‌سایت شما فراهم می‌کند:
 
 -   **غیرفعال کردن راست کلیک**: جلوگیری از باز شدن منوی راست کلیک.
 -   **مسدود کردن ابزارهای توسعه‌دهنده**: مسدود کردن دسترسی به ابزارهای توسعه‌دهنده مرورگر (مانند F12، Ctrl+Shift+I و ...).
@@ -53,8 +54,9 @@ This module provides a robust set of features to protect your website's content:
 
 ## نحوه استفاده
 
-۱. آخرین نسخه ماژول (فایل `.zip`) را دانلود کنید.
-۲. وارد پنل مدیریت پرستاشاپ خود شوید.
-۳. به بخش **ماژول‌ها > مدیریت ماژول** بروید.
-۴. روی دکمه **بارگذاری ماژول** کلیک کرده و فایل `.zip` دانلود شده را انتخاب کنید.
-۵. پس از نصب، روی **پیکربندی** کلیک کرده و قابلیت‌های محافظتی مورد نظر خود را فعال کنید.
+۱. آخرین نسخه پلاگین (فایل `.zip`) را دانلود کنید.
+۲. وارد پنل مدیریت وردپرس خود شوید.
+۳. به بخش **افزونه‌ها > افزودن** بروید.
+۴. روی دکمه **بارگذاری افزونه** کلیک کرده و فایل `.zip` دانلود شده را انتخاب کنید.
+۵. پس از نصب، روی **فعال کردن** کلیک کنید.
+۶. برای پیکربندی، به بخش **تنظیمات > Content Protection** بروید و قابلیت‌های مورد نظر خود را فعال کنید.

--- a/views/css/protect.css
+++ b/views/css/protect.css
@@ -1,28 +1,25 @@
+/* Prevents printing the page content */
 @media print {
     body, html {
         display: none !important;
+        visibility: hidden !important;
     }
 }
 
-.unselectable {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-}
-
-body.enhanced-protection::after {
+/* Enhanced protection layer to deter screenshots */
+.bcp-enhanced-protection::after {
     content: "";
     position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100vh;
     background-color: transparent;
     pointer-events: none;
-    z-index: 999999;
+    z-index: 99999999;
 }
 
-video.protected-video {
-    filter: brightness(1.01);
+/* A small, nearly invisible filter to disrupt screen recording on some browsers */
+.bcp-enhanced-protection video {
+    filter: brightness(1.001);
 }

--- a/views/js/protect.js
+++ b/views/js/protect.js
@@ -1,13 +1,18 @@
 (() => {
-    if (typeof BCP_DISABLE_RIGHTCLICK !== 'undefined' && BCP_DISABLE_RIGHTCLICK) {
+    // Check if bcp_settings is defined
+    if (typeof bcp_settings === 'undefined') {
+        return;
+    }
+
+    if (bcp_settings.BCP_DISABLE_RIGHTCLICK) {
         document.addEventListener('contextmenu', e => e.preventDefault());
     }
 
-    if (typeof BCP_DISABLE_DEVTOOLS !== 'undefined' && BCP_DISABLE_DEVTOOLS) {
+    if (bcp_settings.BCP_DISABLE_DEVTOOLS) {
         document.addEventListener('keydown', e => {
             if (
-                e.key === 'F12' || 
-                (e.ctrlKey && e.shiftKey && ['I', 'J', 'C'].includes(e.key.toUpperCase())) || 
+                e.key === 'F12' ||
+                (e.ctrlKey && e.shiftKey && ['I', 'J', 'C'].includes(e.key.toUpperCase())) ||
                 (e.ctrlKey && e.key.toUpperCase() === 'U')
             ) {
                 e.preventDefault();
@@ -15,7 +20,7 @@
         });
     }
 
-    if (typeof BCP_DISABLE_SCREENSHOT !== 'undefined' && BCP_DISABLE_SCREENSHOT) {
+    if (bcp_settings.BCP_DISABLE_SCREENSHOT) {
         document.addEventListener('keydown', e => {
             if (e.key === 'PrintScreen') {
                 navigator.clipboard.writeText('');
@@ -25,10 +30,9 @@
     }
 
     window.addEventListener('DOMContentLoaded', () => {
-        if (typeof BCP_DISABLE_VIDEO_DOWNLOAD !== 'undefined' && BCP_DISABLE_VIDEO_DOWNLOAD) {
+        if (bcp_settings.BCP_DISABLE_VIDEO_DOWNLOAD) {
             document.querySelectorAll('video').forEach(video => {
                 video.setAttribute('controlsList', 'nodownload');
-                video.removeAttribute('download');
             });
         }
 
@@ -37,27 +41,31 @@
             el.setAttribute('oncontextmenu', 'return false');
         });
 
-        // جلوگیری از انتخاب متن
-        if (typeof BCP_DISABLE_TEXT_SELECTION !== 'undefined' && BCP_DISABLE_TEXT_SELECTION) {
-            document.body.classList.add('unselectable');
+        // Disable text selection
+        if (bcp_settings.BCP_DISABLE_TEXT_SELECTION) {
+            document.body.style.userSelect = 'none';
+            document.body.style.webkitUserSelect = 'none';
+            document.body.style.mozUserSelect = 'none';
+            document.body.style.msUserSelect = 'none';
         }
 
-        // محافظت پیشرفته
-        if (typeof BCP_ENHANCED_PROTECTION !== 'undefined' && BCP_ENHANCED_PROTECTION) {
-            document.body.classList.add('enhanced-protection');
-            document.querySelectorAll('video').forEach(video => {
-                video.classList.add('protected-video');
-            });
+        // Enhanced screen protection
+        if (bcp_settings.BCP_ENHANCED_PROTECTION) {
+            document.body.classList.add('bcp-enhanced-protection');
         }
     });
 
-    // جلوگیری از کپی کردن
-    if (typeof BCP_DISABLE_DBLCLICK_COPY !== 'undefined' && BCP_DISABLE_DBLCLICK_COPY) {
+    // Disable copy
+    if (bcp_settings.BCP_DISABLE_DBLCLICK_COPY) {
         document.addEventListener('copy', e => {
             e.preventDefault();
         });
     }
 
-    // جلوگیری از کشیدن (dragging) تصاویر و ویدیوها
-    document.addEventListener('dragstart', e => e.preventDefault());
+    // Disable drag
+    document.addEventListener('dragstart', e => {
+        if (e.target.tagName === 'IMG' || e.target.tagName === 'VIDEO') {
+            e.preventDefault();
+        }
+    });
 })();


### PR DESCRIPTION
This commit completely refactors the existing PrestaShop module into a standard WordPress plugin.

The main file `blockcontentprotection.php` has been rewritten to use WordPress hooks for activation, deactivation, and script enqueueing. A new admin settings page has been created using the WordPress Settings API.

The frontend JavaScript in `views/js/protect.js` is now localized with settings from the WordPress backend, fixing the original bug where protections were not respecting the configuration.

The 'Enhanced Screen Protection' feature, including the new `views/css/protect.css` file, has been integrated into the WordPress plugin structure.

The `README.md` has been updated to be bilingual and reflect the new WordPress plugin instructions.