### PR TITLE
feat: Add exclusion, custom message, and i18n features

### DIFF
--- a/block-content-protection/block-content-protection.php
+++ b/block-content-protection/block-content-protection.php
@@ -9,6 +9,7 @@
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       block-content-protection
+ * Domain Path:       /languages
  */
 
 if ( ! defined( 'WPINC' ) ) {
@@ -31,33 +32,30 @@ add_action( 'admin_menu', 'bcp_add_admin_menu' );
 function bcp_register_settings() {
     register_setting( 'bcp_settings_group', 'bcp_options', 'bcp_sanitize_options' );
 
-    add_settings_section(
-        'bcp_settings_section',
-        __( 'Protection Settings', 'block-content-protection' ),
-        null,
-        'block_content_protection'
-    );
-
-    $fields = [
+    // Protection Settings Section
+    add_settings_section( 'bcp_protection_section', __( 'Protection Settings', 'block-content-protection' ), null, 'block_content_protection' );
+    $protection_fields = [
         'disable_right_click'    => __( 'Disable Right Click', 'block-content-protection' ),
         'disable_devtools'       => __( 'Disable Developer Tools (F12, etc.)', 'block-content-protection' ),
         'disable_copy'           => __( 'Disable Copy (Ctrl+C)', 'block-content-protection' ),
         'disable_text_selection' => __( 'Disable Text Selection', 'block-content-protection' ),
         'disable_image_drag'     => __( 'Disable Image Dragging', 'block-content-protection' ),
+        'disable_screenshot'     => __( 'Disable Screenshot (PrintScreen)', 'block-content-protection' ),
         'enhanced_protection'    => __( 'Enhanced Screen Protection', 'block-content-protection' ),
     ];
-
-    foreach ($fields as $id => $label) {
-        $description = ($id === 'enhanced_protection') ? __( 'Attempts to block screenshots and screen recording. May not work in all browsers.', 'block-content-protection' ) : '';
-        add_settings_field(
-            $id,
-            $label,
-            'bcp_render_checkbox_field',
-            'block_content_protection',
-            'bcp_settings_section',
-            [ 'id' => $id, 'description' => $description ]
-        );
+    foreach ($protection_fields as $id => $label) {
+        $desc = ($id === 'enhanced_protection') ? __( 'Attempts to block screenshots and screen recording. May not work in all browsers.', 'block-content-protection' ) : '';
+        add_settings_field( $id, $label, 'bcp_render_checkbox_field', 'block_content_protection', 'bcp_protection_section', [ 'id' => $id, 'description' => $desc ] );
     }
+
+    // Exclusions Section
+    add_settings_section( 'bcp_exclusions_section', __( 'Exclusion Settings', 'block-content-protection' ), null, 'block_content_protection' );
+    add_settings_field( 'whitelisted_ips', __( 'Whitelisted IP Addresses', 'block-content-protection' ), 'bcp_render_textarea_field', 'block_content_protection', 'bcp_exclusions_section', [ 'id' => 'whitelisted_ips', 'description' => __( 'Enter one IP address per line. These IPs will not be affected by the protection.', 'block-content-protection' ) ] );
+    add_settings_field( 'excluded_pages', __( 'Excluded Posts/Pages', 'block-content-protection' ), 'bcp_render_textfield_field', 'block_content_protection', 'bcp_exclusions_section', [ 'id' => 'excluded_pages', 'description' => __( 'Enter a comma-separated list of Post or Page IDs to exclude from protection (e.g., 1, 2, 3).', 'block-content-protection' ) ] );
+
+    // Messages Section
+    add_settings_section( 'bcp_messages_section', __( 'Custom Messages', 'block-content-protection' ), null, 'block_content_protection' );
+    add_settings_field( 'screenshot_alert_message', __( 'Screenshot Alert Message', 'block-content-protection' ), 'bcp_render_textfield_field', 'block_content_protection', 'bcp_messages_section', [ 'id' => 'screenshot_alert_message', 'description' => __( 'The message shown when a user tries to take a screenshot.', 'block-content-protection' ) ] );
 }
 add_action( 'admin_init', 'bcp_register_settings' );
 
@@ -72,22 +70,47 @@ function bcp_render_checkbox_field( $args ) {
     echo "</label>";
 }
 
+function bcp_render_textarea_field( $args ) {
+    $options = get_option( 'bcp_options', [] );
+    $id = $args['id'];
+    $value = isset( $options[$id] ) ? esc_textarea( $options[$id] ) : '';
+    echo "<textarea id='$id' name='bcp_options[$id]' rows='5' cols='50' class='large-text code'>$value</textarea>";
+    if ( ! empty( $args['description'] ) ) {
+        echo '<p class="description">' . esc_html( $args['description'] ) . '</p>';
+    }
+}
+
+function bcp_render_textfield_field( $args ) {
+    $options = get_option( 'bcp_options', [] );
+    $id = $args['id'];
+    $value = isset( $options[$id] ) ? esc_attr( $options[$id] ) : '';
+    echo "<input type='text' id='$id' name='bcp_options[$id]' value='$value' class='regular-text' />";
+    if ( ! empty( $args['description'] ) ) {
+        echo '<p class="description">' . esc_html( $args['description'] ) . '</p>';
+    }
+}
+
 function bcp_sanitize_options( $input ) {
     $sanitized_input = [];
-    $fields = [
-        'disable_right_click',
-        'disable_devtools',
-        'disable_copy',
-        'disable_text_selection',
-        'disable_image_drag',
-        'enhanced_protection',
-    ];
-
-    if ( is_array( $input ) ) {
-        foreach ( $fields as $field ) {
-            $sanitized_input[$field] = ! empty( $input[$field] ) ? 1 : 0;
-        }
+    if ( ! is_array( $input ) ) {
+        return $sanitized_input;
     }
+
+    $checkboxes = [ 'disable_right_click', 'disable_devtools', 'disable_copy', 'disable_text_selection', 'disable_image_drag', 'disable_screenshot', 'enhanced_protection' ];
+    foreach ( $checkboxes as $field ) {
+        $sanitized_input[$field] = ! empty( $input[$field] ) ? 1 : 0;
+    }
+
+    if ( isset( $input['whitelisted_ips'] ) ) {
+        $sanitized_input['whitelisted_ips'] = implode( "\n", array_map( 'sanitize_text_field', explode( "\n", $input['whitelisted_ips'] ) ) );
+    }
+    if ( isset( $input['excluded_pages'] ) ) {
+        $sanitized_input['excluded_pages'] = sanitize_text_field( $input['excluded_pages'] );
+    }
+    if ( isset( $input['screenshot_alert_message'] ) ) {
+        $sanitized_input['screenshot_alert_message'] = sanitize_text_field( $input['screenshot_alert_message'] );
+    }
+
     return $sanitized_input;
 }
 
@@ -107,30 +130,53 @@ function bcp_options_page() {
     <?php
 }
 
+function bcp_get_user_ip() {
+    $ip_keys = [ 'HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR' ];
+    foreach ( $ip_keys as $key ) {
+        if ( array_key_exists( $key, $_SERVER ) === true ) {
+            foreach ( explode( ',', $_SERVER[ $key ] ) as $ip ) {
+                $ip = trim( $ip );
+                if ( filter_var( $ip, FILTER_VALIDATE_IP ) !== false ) {
+                    return $ip;
+                }
+            }
+        }
+    }
+    return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
+}
+
 function bcp_enqueue_scripts() {
     $options = get_option( 'bcp_options', [] );
 
-    // Check if at least one protection is enabled.
-    $is_protection_enabled = in_array(1, $options);
+    // --- Exclusion Logic ---
+    if ( ! empty( $options['whitelisted_ips'] ) ) {
+        $whitelisted_ips = array_map( 'trim', explode( "\n", $options['whitelisted_ips'] ) );
+        if ( in_array( bcp_get_user_ip(), $whitelisted_ips, true ) ) {
+            return;
+        }
+    }
+    if ( ! empty( $options['excluded_pages'] ) && is_singular() ) {
+        $excluded_pages = array_map( 'trim', explode( ',', $options['excluded_pages'] ) );
+        if ( in_array( (string) get_the_ID(), $excluded_pages, true ) ) {
+            return;
+        }
+    }
+
+    $protection_options = [ 'disable_right_click', 'disable_devtools', 'disable_copy', 'disable_text_selection', 'disable_image_drag', 'disable_screenshot', 'enhanced_protection' ];
+    $is_protection_enabled = false;
+    foreach( $protection_options as $key ) {
+        if ( ! empty( $options[$key] ) ) {
+            $is_protection_enabled = true;
+            break;
+        }
+    }
 
     if ( $is_protection_enabled ) {
-        wp_enqueue_script(
-            'bcp-protect',
-            BCP_PLUGIN_URL . 'js/protect.js',
-            [],
-            '1.3.0',
-            true
-        );
+        wp_enqueue_script( 'bcp-protect', BCP_PLUGIN_URL . 'js/protect.js', [], '1.3.0', true );
         wp_localize_script( 'bcp-protect', 'bcp_settings', $options );
 
-        // Conditionally enqueue CSS for enhanced protection
         if ( ! empty( $options['enhanced_protection'] ) ) {
-            wp_enqueue_style(
-                'bcp-protect-css',
-                BCP_PLUGIN_URL . 'css/protect.css',
-                [],
-                '1.3.0'
-            );
+            wp_enqueue_style( 'bcp-protect-css', BCP_PLUGIN_URL . 'css/protect.css', [], '1.3.0' );
         }
     }
 }
@@ -138,12 +184,16 @@ add_action( 'wp_enqueue_scripts', 'bcp_enqueue_scripts' );
 
 function bcp_activation() {
     $defaults = [
-        'disable_right_click'    => 1,
-        'disable_devtools'       => 1,
-        'disable_copy'           => 1,
-        'disable_text_selection' => 1,
-        'disable_image_drag'     => 1,
-        'enhanced_protection'    => 0,
+        'disable_right_click'      => 1,
+        'disable_devtools'         => 1,
+        'disable_copy'             => 1,
+        'disable_text_selection'   => 1,
+        'disable_image_drag'       => 1,
+        'disable_screenshot'       => 1,
+        'enhanced_protection'      => 0,
+        'whitelisted_ips'          => '',
+        'excluded_pages'           => '',
+        'screenshot_alert_message' => 'Screenshots are disabled on this site.',
     ];
     if ( false === get_option( 'bcp_options' ) ) {
         update_option( 'bcp_options', $defaults );

--- a/block-content-protection/js/protect.js
+++ b/block-content-protection/js/protect.js
@@ -9,13 +9,24 @@
         document.addEventListener('contextmenu', e => e.preventDefault(), false);
     }
 
-    // Disable Developer Tools
-    if (bcp_settings.disable_devtools) {
+    // Disable Developer Tools & Screenshot
+    if (bcp_settings.disable_devtools || bcp_settings.disable_screenshot) {
         document.addEventListener('keydown', e => {
-            if (e.key === 'F12' ||
-               (e.ctrlKey && e.shiftKey && ['I', 'J', 'C'].includes(e.key.toUpperCase())) ||
-               (e.ctrlKey && e.key.toUpperCase() === 'U')) {
+            // DevTools
+            if (bcp_settings.disable_devtools) {
+                if (e.key === 'F12' ||
+                   (e.ctrlKey && e.shiftKey && ['I', 'J', 'C'].includes(e.key.toUpperCase())) ||
+                   (e.ctrlKey && e.key.toUpperCase() === 'U')) {
+                    e.preventDefault();
+                }
+            }
+            // Screenshot
+            if (bcp_settings.disable_screenshot && e.key === 'PrintScreen') {
                 e.preventDefault();
+                navigator.clipboard.writeText('');
+                if (bcp_settings.screenshot_alert_message) {
+                    alert(bcp_settings.screenshot_alert_message);
+                }
             }
         });
     }

--- a/block-content-protection/languages/block-content-protection.pot
+++ b/block-content-protection/languages/block-content-protection.pot
@@ -1,0 +1,92 @@
+# Copyright (C) 2025 Mohammad Babaei
+# This file is distributed under the same license as the Block Content Protection plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: Block Content Protection 1.3.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/your-plugin-slug\n"
+"POT-Creation-Date: 2025-09-29 14:00:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Jules\n"
+
+#: ../block-content-protection.php:21
+#: ../block-content-protection.php:22
+msgid "Content Protection"
+msgstr ""
+
+#: ../block-content-protection.php:33
+msgid "Protection Settings"
+msgstr ""
+
+#: ../block-content-protection.php:35
+msgid "Disable Right Click"
+msgstr ""
+
+#: ../block-content-protection.php:36
+msgid "Disable Developer Tools (F12, etc.)"
+msgstr ""
+
+#: ../block-content-protection.php:37
+msgid "Disable Copy (Ctrl+C)"
+msgstr ""
+
+#: ../block-content-protection.php:38
+msgid "Disable Text Selection"
+msgstr ""
+
+#: ../block-content-protection.php:39
+msgid "Disable Image Dragging"
+msgstr ""
+
+#: ../block-content-protection.php:40
+msgid "Disable Screenshot (PrintScreen)"
+msgstr ""
+
+#: ../block-content-protection.php:41
+msgid "Enhanced Screen Protection"
+msgstr ""
+
+#: ../block-content-protection.php:44
+msgid "Attempts to block screenshots and screen recording. May not work in all browsers."
+msgstr ""
+
+#: ../block-content-protection.php:50
+msgid "Exclusion Settings"
+msgstr ""
+
+#: ../block-content-protection.php:51
+msgid "Whitelisted IP Addresses"
+msgstr ""
+
+#: ../block-content-protection.php:51
+msgid "Enter one IP address per line. These IPs will not be affected by the protection."
+msgstr ""
+
+#: ../block-content-protection.php:52
+msgid "Excluded Posts/Pages"
+msgstr ""
+
+#: ../block-content-protection.php:52
+msgid "Enter a comma-separated list of Post or Page IDs to exclude from protection (e.g., 1, 2, 3)."
+msgstr ""
+
+#: ../block-content-protection.php:55
+msgid "Custom Messages"
+msgstr ""
+
+#: ../block-content-protection.php:56
+msgid "Screenshot Alert Message"
+msgstr ""
+
+#: ../block-content-protection.php:56
+msgid "The message shown when a user tries to take a screenshot."
+msgstr ""
+
+#: ../block-content-protection.php:127
+msgid "Save Settings"
+msgstr ""


### PR DESCRIPTION
This commit adds several major features to the WordPress content protection plugin:

1.  **Exclusion Rules**:
    - Implemented an IP whitelist feature to bypass protection for specific IP addresses.
    - Added an option to exclude specific posts and pages from protection based on their IDs.
    - The backend logic in `bcp_enqueue_scripts` now checks these rules before loading the protection scripts.

2.  **Customizable Messages**:
    - Added a setting to allow users to define a custom alert message for the screenshot protection feature.
    - The `protect.js` file has been updated to use this custom message.

3.  **Internationalization**:
    - Added `Domain Path` to the plugin header.
    - Created a `languages` directory and generated a `block-content-protection.pot` file, making the plugin fully translatable.

4.  **Code Refinements**:
    - Restructured the admin settings page for better organization.
    - Updated the activation hook to include default values for the new options.