### PR TITLE
feat: Final WordPress plugin with all features

### DIFF
--- a/block-content-protection/block-content-protection.php
+++ b/block-content-protection/block-content-protection.php
@@ -40,6 +40,7 @@ function bcp_register_settings() {
         'disable_copy'           => __( 'Disable Copy (Ctrl+C)', 'block-content-protection' ),
         'disable_text_selection' => __( 'Disable Text Selection', 'block-content-protection' ),
         'disable_image_drag'     => __( 'Disable Image Dragging', 'block-content-protection' ),
+        'disable_video_download' => __( 'Disable Video Download', 'block-content-protection' ),
         'disable_screenshot'     => __( 'Disable Screenshot (PrintScreen)', 'block-content-protection' ),
         'enhanced_protection'    => __( 'Enhanced Screen Protection', 'block-content-protection' ),
     ];
@@ -96,7 +97,7 @@ function bcp_sanitize_options( $input ) {
         return $sanitized_input;
     }
 
-    $checkboxes = [ 'disable_right_click', 'disable_devtools', 'disable_copy', 'disable_text_selection', 'disable_image_drag', 'disable_screenshot', 'enhanced_protection' ];
+    $checkboxes = [ 'disable_right_click', 'disable_devtools', 'disable_copy', 'disable_text_selection', 'disable_image_drag', 'disable_video_download', 'disable_screenshot', 'enhanced_protection' ];
     foreach ( $checkboxes as $field ) {
         $sanitized_input[$field] = ! empty( $input[$field] ) ? 1 : 0;
     }
@@ -189,6 +190,7 @@ function bcp_activation() {
         'disable_copy'             => 1,
         'disable_text_selection'   => 1,
         'disable_image_drag'       => 1,
+        'disable_video_download'   => 1,
         'disable_screenshot'       => 1,
         'enhanced_protection'      => 0,
         'whitelisted_ips'          => '',

--- a/block-content-protection/js/protect.js
+++ b/block-content-protection/js/protect.js
@@ -58,4 +58,11 @@
         document.body.classList.add('bcp-enhanced-protection');
     }
 
+    // Disable Video Download
+    if (bcp_settings.disable_video_download) {
+        document.querySelectorAll('video').forEach(video => {
+            video.setAttribute('controlsList', 'nodownload');
+        });
+    }
+
 })();

--- a/block-content-protection/languages/block-content-protection.pot
+++ b/block-content-protection/languages/block-content-protection.pot
@@ -44,6 +44,10 @@ msgid "Disable Image Dragging"
 msgstr ""
 
 #: ../block-content-protection.php:40
+msgid "Disable Video Download"
+msgstr ""
+
+#: ../block-content-protection.php:41
 msgid "Disable Screenshot (PrintScreen)"
 msgstr ""
 


### PR DESCRIPTION
This commit delivers the final version of the content protection WordPress plugin.

It includes the full conversion from the original PrestaShop module and adds several advanced features requested by the user:
1.  **Exclusion Rules**: IP whitelisting and page/post exclusion.
2.  **Customizable Messages**: A setting for the screenshot alert message.
3.  **Internationalization**: A `.pot` file for translations.

This version also restores the 'Disable Video Download' feature that was accidentally omitted in a previous refactoring. The codebase is now clean, feature-complete according to user requests, and follows WordPress best practices.