### PR TITLE
feat: Improve screenshot blocking for macOS and clarify UI text

### DIFF
--- a/block-content-protection/block-content-protection.php
+++ b/block-content-protection/block-content-protection.php
@@ -41,11 +41,17 @@ function bcp_register_settings() {
         'disable_text_selection' => __( 'Disable Text Selection', 'block-content-protection' ),
         'disable_image_drag'     => __( 'Disable Image Dragging', 'block-content-protection' ),
         'disable_video_download' => __( 'Disable Video Download', 'block-content-protection' ),
-        'disable_screenshot'     => __( 'Disable Screenshot (PrintScreen)', 'block-content-protection' ),
+        'disable_screenshot'     => __( 'Disable Screenshot Shortcuts', 'block-content-protection' ),
         'enhanced_protection'    => __( 'Enhanced Screen Protection', 'block-content-protection' ),
     ];
     foreach ($protection_fields as $id => $label) {
-        $desc = ($id === 'enhanced_protection') ? __( 'Attempts to block screenshots and screen recording. May not work in all browsers.', 'block-content-protection' ) : '';
+        $desc = '';
+        if ($id === 'disable_screenshot') {
+            $desc = __( 'Blocks PrintScreen and macOS screenshot shortcuts (Cmd+Shift+3/4).', 'block-content-protection' );
+        }
+        if ($id === 'enhanced_protection') {
+            $desc = __( 'Applies additional CSS to interfere with screen capture. Note: These methods are not foolproof and can be bypassed.', 'block-content-protection' );
+        }
         add_settings_field( $id, $label, 'bcp_render_checkbox_field', 'block_content_protection', 'bcp_protection_section', [ 'id' => $id, 'description' => $desc ] );
     }
 

--- a/block-content-protection/js/protect.js
+++ b/block-content-protection/js/protect.js
@@ -20,12 +20,21 @@
                     e.preventDefault();
                 }
             }
+
             // Screenshot
-            if (bcp_settings.disable_screenshot && e.key === 'PrintScreen') {
-                e.preventDefault();
-                navigator.clipboard.writeText('');
-                if (bcp_settings.screenshot_alert_message) {
-                    alert(bcp_settings.screenshot_alert_message);
+            if (bcp_settings.disable_screenshot) {
+                // Windows: PrintScreen
+                // macOS: Cmd+Shift+3, Cmd+Shift+4
+                const isPrintScreen = e.key === 'PrintScreen';
+                const isMacScreenshot = e.metaKey && e.shiftKey && (e.key === '3' || e.key === '4');
+
+                if (isPrintScreen || isMacScreenshot) {
+                    e.preventDefault();
+                    // Attempt to clear clipboard to prevent pasting the screenshot
+                    navigator.clipboard.writeText('');
+                    if (bcp_settings.screenshot_alert_message) {
+                        alert(bcp_settings.screenshot_alert_message);
+                    }
                 }
             }
         });


### PR DESCRIPTION
This commit enhances the screenshot protection feature by adding JavaScript logic to detect and block common macOS screenshot keyboard shortcuts (Cmd+Shift+3 and Cmd+Shift+4), in addition to the existing block for the PrintScreen key.

The descriptions in the plugin's admin settings have also been updated to more accurately reflect the new capabilities and to clarify that while these methods interfere with common shortcuts, they cannot provide foolproof protection against all screen capture methods.